### PR TITLE
Bugfix: Round shipping tax rate to 2 digits instead of 0

### DIFF
--- a/Helper/Content/ShoppingBasket/Shipping.php
+++ b/Helper/Content/ShoppingBasket/Shipping.php
@@ -33,7 +33,7 @@ class Shipping extends \Magento\Framework\App\Helper\AbstractHelper
         $content = [
             'Description' => $quoteOrOrder->getShippingDescription(),
             'UnitPriceGross' => round($quoteOrOrder->getShippingInclTax(),2),
-            'TaxRate' => round(($quoteOrOrder->getShippingTaxAmount() / $quoteOrOrder->getShippingAmount()) * 100)
+            'TaxRate' => round(($quoteOrOrder->getShippingTaxAmount() / $quoteOrOrder->getShippingAmount()) * 100, 2)
             //'DescriptionAddition' => "Additional information about the shipping"
         ];
         return $content;


### PR DESCRIPTION
That's needed for Swiss tax rates of 2.5% or 7.7% for example. It's rounded to hard coded 2 digits in \RatePAY\Payment\Helper\Content\ShoppingBasket\Items::setItems too for example