### PR TITLE
Remove override of checkout layout attribute

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="RatePAY_Payment::css/ratepay.css"/>
     </head>


### PR DESCRIPTION
By defining `layout="1column"`, this overrides the default layout of `checkout` which is defined [here](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml#L8). Removing this incorrect `1column` definition makes the checkout route use the correct `page_layout`.

Setting the page layout to `1column` removes (or rather, doesn't process) the [`page_layout`](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/page_layout/checkout.xml) that should be being used. This causes other extensions to not work as expected. In one case, the header changes we make specifically for the checkout were not processed, because the container `checkout.header.wrapper` no longer existed.